### PR TITLE
unify common rules to simplify .editorconfig

### DIFF
--- a/{{cookiecutter.project_slug}}/.editorconfig
+++ b/{{cookiecutter.project_slug}}/.editorconfig
@@ -7,25 +7,17 @@ charset = utf-8
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
-
-[*.{py,rst,ini}]
 indent_style = space
 indent_size = 4
 
-[*.{html,css,scss,json,yml}]
-indent_style = space
-indent_size = 4
-
-[*.md]
+[*.{md,sql}]
 trim_trailing_whitespace = false
 
 [Makefile]
 indent_style = tab
 
 [nginx.conf]
-indent_style = space
 indent_size = 2
 
 [*.{yml}]
-indent_style = space
 indent_size = 2


### PR DESCRIPTION
* combining rules to make this easier to read/understand
* add rule to .sql files to not remove trailing whitespace (common in SQL dumps)